### PR TITLE
fix: update Dockerfile buf copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml ./
 RUN buf generate buf.build/agynio/api \
     --path agynio/api/tenants/v1 \
     --path agynio/api/authorization/v1


### PR DESCRIPTION
## Summary
- update Dockerfile to only copy buf.gen.yaml now that buf.yaml is removed
- verify buf generate continues to work via BSR inputs

## Testing
- go test ./...
- go build ./...
- helm dependency build charts/tenants
- helm lint charts/tenants
- buf generate buf.build/agynio/api --path agynio/api/tenants/v1 --path agynio/api/authorization/v1

## Issue
- #1