### PR TITLE
fix(config): default authorization address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml ./
 RUN buf generate buf.build/agynio/api \
     --path agynio/api/tenants/v1 \
     --path agynio/api/authorization/v1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,7 @@ func FromEnv() (Config, error) {
 	}
 	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
 	if cfg.AuthorizationAddress == "" {
-		return Config{}, fmt.Errorf("AUTHORIZATION_ADDRESS must be set")
+		cfg.AuthorizationAddress = "authorization:50051"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary
- default AUTHORIZATION_ADDRESS to authorization:50051 in service config

## Testing
- go test ./...
- go build ./...
- helm dependency build charts/tenants
- helm lint charts/tenants

## Issue
- #1