### PR TITLE
chore(ci): add e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         run: echo "KUBECONFIG=$GITHUB_WORKSPACE/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
 
       - name: Run e2e tests
-        run: devspace run test:e2e
+        run: devspace run test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/bootstrap
-          path: ${{ runner.temp }}/bootstrap
+          path: bootstrap
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
@@ -70,17 +70,15 @@ jobs:
           devspace version
 
       - name: Provision cluster
-        run: |
-          cd ${{ runner.temp }}/bootstrap
-          ./apply.sh -y
+        run: ./apply.sh -y
+        working-directory: bootstrap
 
       - name: Verify platform workloads and Argo CD health
-        run: |
-          cd ${{ runner.temp }}/bootstrap
-          ./.github/scripts/verify_platform_health.sh
+        run: ./.github/scripts/verify_platform_health.sh
+        working-directory: bootstrap
 
       - name: Set kubeconfig
-        run: echo "KUBECONFIG=${{ runner.temp }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
+        run: echo "KUBECONFIG=$GITHUB_WORKSPACE/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
 
       - name: Run e2e tests
         run: devspace run test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,55 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+  e2e:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout tenants
+        uses: actions/checkout@v4
+
+      - name: Checkout bootstrap
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/bootstrap
+          path: bootstrap
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.34.3
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+          k3d version
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Install DevSpace
+        run: |
+          curl -sSL https://github.com/devspace-sh/devspace/releases/latest/download/devspace-linux-amd64 -o /tmp/devspace
+          sudo install -m 0755 /tmp/devspace /usr/local/bin/devspace
+          devspace version
+
+      - name: Provision cluster
+        run: |
+          cd bootstrap
+          ./apply.sh -y
+
+      - name: Verify platform workloads and Argo CD health
+        run: |
+          cd bootstrap
+          ./.github/scripts/verify_platform_health.sh
+
+      - name: Set kubeconfig
+        run: echo "KUBECONFIG=$GITHUB_WORKSPACE/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
+
+      - name: Run e2e tests
+        run: devspace run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: agynio/bootstrap
-          path: bootstrap
+          path: ${{ runner.temp }}/bootstrap
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v4
@@ -71,16 +71,16 @@ jobs:
 
       - name: Provision cluster
         run: |
-          cd bootstrap
+          cd ${{ runner.temp }}/bootstrap
           ./apply.sh -y
 
       - name: Verify platform workloads and Argo CD health
         run: |
-          cd bootstrap
+          cd ${{ runner.temp }}/bootstrap
           ./.github/scripts/verify_platform_health.sh
 
       - name: Set kubeconfig
-        run: echo "KUBECONFIG=$GITHUB_WORKSPACE/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
+        run: echo "KUBECONFIG=${{ runner.temp }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml" >> "$GITHUB_ENV"
 
       - name: Run e2e tests
         run: devspace run test-e2e

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -85,11 +85,22 @@ deployments:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          fsGroup: 1000
         containers:
           - image: ${E2E_IMAGE}
             env:
               - name: TENANTS_ADDR
                 value: "tenants:50051"
+            volumeMounts:
+              - containerPath: /opt/app/data
+                volume:
+                  name: e2e-data
+        volumes:
+          - name: e2e-data
+            emptyDir: {}
         labels:
           app.kubernetes.io/name: tenants-e2e
 
@@ -131,10 +142,37 @@ pipelines:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &
+
+      echo "Waiting for sync to complete..."
+      SYNC_READY=false
+      for i in $(seq 1 60); do
+        if exec_container \
+          --label-selector "app.kubernetes.io/name=tenants-e2e" \
+          -n ${TENANTS_NAMESPACE} \
+          -- test -f /opt/app/data/go.mod 2>/dev/null; then
+          SYNC_READY=true
+          break
+        fi
+        sleep 2
+      done
+
+      if [ "$SYNC_READY" != "true" ]; then
+        echo "ERROR: sync did not complete within 120s" >&2
+        stop_dev e2e-runner || true
+        purge_deployments e2e-runner || true
+        exit 1
+      fi
+
+      echo "Sync complete. Running e2e tests..."
       exec_container \
         --label-selector "app.kubernetes.io/name=tenants-e2e" \
         -n ${TENANTS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && for i in $(seq 1 30); do [ -f buf.gen.yaml ] && break; echo "Waiting for sync..."; sleep 2; done && buf generate buf.build/agynio/api --path agynio/api/tenants/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c '
+          set -eu
+          cd /opt/app/data
+          buf generate buf.build/agynio/api --path agynio/api/tenants/v1 --path agynio/api/authorization/v1
+          go test -v -count=1 -tags e2e ./test/e2e/
+        '
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -194,3 +194,4 @@ dev:
           - .devspace/
           - /.gen/
           - /tmp/
+          - /bootstrap/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -94,8 +94,8 @@ deployments:
           app.kubernetes.io/name: tenants-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -127,7 +127,7 @@ pipelines:
         stop_dev tenants
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -131,11 +131,10 @@ pipelines:
     run: |-
       create_deployments e2e-runner
       start_dev e2e-runner &
-      sleep 5
       exec_container \
         --label-selector "app.kubernetes.io/name=tenants-e2e" \
         -n ${TENANTS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/tenants/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && for i in $(seq 1 30); do [ -f buf.gen.yaml ] && break; echo "Waiting for sync..."; sleep 2; done && buf generate buf.build/agynio/api --path agynio/api/tenants/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner


### PR DESCRIPTION
## Summary
- add an e2e job to the CI workflow that provisions a bootstrap cluster and runs DevSpace e2e tests
- align kubectl/k3d/terraform versions with bootstrap workflow

## Testing
- go test ./...
- go build ./...
- helm dependency build charts/tenants
- helm lint charts/tenants

## Issue
- #1