### PR TITLE
feat(server): write owner tuple on create

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,7 +15,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const organizationObjectPrefix = "organization:"
+const (
+	organizationObjectPrefix = "organization:"
+	identityObjectPrefix     = "identity:"
+)
 
 type Server struct {
 	organizationsv1.UnimplementedOrganizationsServiceServer
@@ -27,19 +30,16 @@ func New(store *store.Store, authorizationClient authorizationv1.AuthorizationSe
 	return &Server{store: store, authorizationClient: authorizationClient}
 }
 
-func identityIDFromContext(ctx context.Context) (string, error) {
+func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return "", fmt.Errorf("no metadata in context")
+		return uuid.Nil, fmt.Errorf("no metadata in context")
 	}
 	values := md.Get("x-identity-id")
 	if len(values) == 0 || values[0] == "" {
-		return "", fmt.Errorf("x-identity-id not found in metadata")
+		return uuid.Nil, fmt.Errorf("x-identity-id not found in metadata")
 	}
-	if _, err := uuid.Parse(values[0]); err != nil {
-		return "", fmt.Errorf("invalid identity id: %v", err)
-	}
-	return values[0], nil
+	return uuid.Parse(values[0])
 }
 
 func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest) (*organizationsv1.CreateOrganizationResponse, error) {
@@ -56,13 +56,14 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 	_, err = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
 		Writes: []*authorizationv1.TupleKey{
 			{
-				User:     fmt.Sprintf("identity:%s", identityID),
+				User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
 				Relation: "owner",
 				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organization.ID.String()),
 			},
 		},
 	})
 	if err != nil {
+		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, status.Errorf(codes.Internal, "failed to write ownership tuple: %v", err)
 	}
 	return &organizationsv1.CreateOrganizationResponse{Organization: toProtoOrganization(organization)}, nil
@@ -135,7 +136,7 @@ func (s *Server) ListAccessibleOrganizations(ctx context.Context, req *organizat
 	authResponse, err := s.authorizationClient.ListObjects(ctx, &authorizationv1.ListObjectsRequest{
 		Type:     "organization",
 		Relation: "member",
-		User:     fmt.Sprintf("identity:%s", identityID.String()),
+		User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
 	})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "authorization list objects: %v", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agynio/organizations/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -26,10 +27,43 @@ func New(store *store.Store, authorizationClient authorizationv1.AuthorizationSe
 	return &Server{store: store, authorizationClient: authorizationClient}
 }
 
+func identityIDFromContext(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("no metadata in context")
+	}
+	values := md.Get("x-identity-id")
+	if len(values) == 0 || values[0] == "" {
+		return "", fmt.Errorf("x-identity-id not found in metadata")
+	}
+	if _, err := uuid.Parse(values[0]); err != nil {
+		return "", fmt.Errorf("invalid identity id: %v", err)
+	}
+	return values[0], nil
+}
+
 func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest) (*organizationsv1.CreateOrganizationResponse, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
 	organization, err := s.store.CreateOrganization(ctx, store.OrganizationInput{Name: req.GetName()})
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+
+	_, err = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+		Writes: []*authorizationv1.TupleKey{
+			{
+				User:     fmt.Sprintf("identity:%s", identityID),
+				Relation: "owner",
+				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organization.ID.String()),
+			},
+		},
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to write ownership tuple: %v", err)
 	}
 	return &organizationsv1.CreateOrganizationResponse{Organization: toProtoOrganization(organization)}, nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -33,11 +34,14 @@ func TestOrganizationsServiceE2E(t *testing.T) {
 	client := organizationsv1.NewOrganizationsServiceClient(conn)
 
 	testID := uuid.NewString()
-	organizationResp1, err := client.CreateOrganization(ctx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Alpha " + testID})
+	identityID := uuid.NewString()
+	identityCtx := identityContext(ctx, identityID)
+
+	organizationResp1, err := client.CreateOrganization(identityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Alpha " + testID})
 	require.NoError(t, err)
 	organizationID1 := organizationResp1.Organization.Id
 
-	organizationResp2, err := client.CreateOrganization(ctx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Beta " + testID})
+	organizationResp2, err := client.CreateOrganization(identityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Beta " + testID})
 	require.NoError(t, err)
 	organizationID2 := organizationResp2.Organization.Id
 
@@ -61,6 +65,11 @@ func TestOrganizationsServiceE2E(t *testing.T) {
 	require.True(t, hasID(organizations, organizationID1))
 	require.True(t, hasID(organizations, organizationID2))
 
+	accessibleResp, err := client.ListAccessibleOrganizations(ctx, &organizationsv1.ListAccessibleOrganizationsRequest{IdentityId: identityID})
+	require.NoError(t, err)
+	require.True(t, hasID(accessibleResp.Organizations, organizationID1))
+	require.True(t, hasID(accessibleResp.Organizations, organizationID2))
+
 	_, err = client.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{Id: organizationID1})
 	requireStatusCode(t, err, codes.InvalidArgument)
 
@@ -71,6 +80,13 @@ func TestOrganizationsServiceE2E(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.DeleteOrganization(ctx, &organizationsv1.DeleteOrganizationRequest{Id: organizationID1})
 	require.NoError(t, err)
+
+	_, err = client.CreateOrganization(ctx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Missing Metadata " + testID})
+	requireStatusCode(t, err, codes.Unauthenticated)
+
+	invalidIdentityCtx := identityContext(ctx, "not-a-uuid")
+	_, err = client.CreateOrganization(invalidIdentityCtx, &organizationsv1.CreateOrganizationRequest{Name: "Organization Invalid Metadata " + testID})
+	requireStatusCode(t, err, codes.Unauthenticated)
 }
 
 func listPaged[T any](t *testing.T, resource string, fetch func(pageToken string) ([]T, string, error)) []T {
@@ -98,6 +114,10 @@ func listOrganizations(ctx context.Context, t *testing.T, client organizationsv1
 		}
 		return resp.Organizations, resp.NextPageToken, nil
 	})
+}
+
+func identityContext(ctx context.Context, identityID string) context.Context {
+	return metadata.NewOutgoingContext(ctx, metadata.Pairs("x-identity-id", identityID))
 }
 
 func hasID(items []*organizationsv1.Organization, id string) bool {


### PR DESCRIPTION
## Summary
- add identity metadata extraction helper for create requests
- write organization owner tuple after creating organizations

## Testing
- go test ./...
- go vet ./...
- go build ./...

Closes #10