### PR TITLE
feat(memberships): add membership management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY buf.gen.yaml ./
 RUN buf generate buf.build/agynio/api \
     --path agynio/api/organizations/v1 \
-    --path agynio/api/authorization/v1
+    --path agynio/api/authorization/v1 \
+    --path agynio/api/identity/v1
 
 COPY . .
 

--- a/charts/organizations/values.yaml
+++ b/charts/organizations/values.yaml
@@ -76,6 +76,8 @@ env:
     value: ""
   - name: AUTHORIZATION_ADDRESS
     value: ""
+  - name: IDENTITY_ADDRESS
+    value: ""
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/cmd/organizations-service/main.go
+++ b/cmd/organizations-service/main.go
@@ -52,7 +52,7 @@ func run() error {
 		return fmt.Errorf("apply migrations: %w", err)
 	}
 
-	authConn, err := grpc.DialContext(ctx, cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	authConn, err := grpc.NewClient(cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return fmt.Errorf("connect to authorization: %w", err)
 	}

--- a/cmd/organizations-service/main.go
+++ b/cmd/organizations-service/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
@@ -57,8 +58,18 @@ func run() error {
 	}
 	defer authConn.Close()
 
+	identityConn, err := grpc.NewClient(cfg.IdentityAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to identity: %w", err)
+	}
+	defer identityConn.Close()
+
 	grpcServer := grpc.NewServer()
-	serverInstance := server.New(store.New(pool), authorizationv1.NewAuthorizationServiceClient(authConn))
+	serverInstance := server.New(
+		store.New(pool),
+		authorizationv1.NewAuthorizationServiceClient(authConn),
+		identityv1.NewIdentityServiceClient(identityConn),
+	)
 	organizationsv1.RegisterOrganizationsServiceServer(grpcServer, serverInstance)
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1
+                  buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
                   exec go run ./cmd/organizations-service
               volumeMounts:
                 - name: data
@@ -176,7 +176,7 @@ pipelines:
         -- bash -c '
           set -eu
           cd /opt/app/data
-          buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1
+          buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
           go test -v -count=1 -tags e2e ./test/e2e/
         '
       EXIT_CODE=$?

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	GRPCAddress          string
 	DatabaseURL          string
 	AuthorizationAddress string
+	IdentityAddress      string
 }
 
 func FromEnv() (Config, error) {
@@ -24,6 +25,10 @@ func FromEnv() (Config, error) {
 	cfg.AuthorizationAddress = os.Getenv("AUTHORIZATION_ADDRESS")
 	if cfg.AuthorizationAddress == "" {
 		cfg.AuthorizationAddress = "authorization:50051"
+	}
+	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
+	if cfg.IdentityAddress == "" {
+		cfg.IdentityAddress = "identity:50051"
 	}
 	return cfg, nil
 }

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
 	"github.com/agynio/organizations/internal/store"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -12,5 +14,68 @@ func toProtoOrganization(organization store.Organization) *organizationsv1.Organ
 		Name:      organization.Name,
 		CreatedAt: timestamppb.New(organization.CreatedAt),
 		UpdatedAt: timestamppb.New(organization.UpdatedAt),
+	}
+}
+
+func toStoreMembershipRole(role organizationsv1.MembershipRole) (store.MembershipRole, error) {
+	switch role {
+	case organizationsv1.MembershipRole_MEMBERSHIP_ROLE_OWNER:
+		return store.MembershipRoleOwner, nil
+	case organizationsv1.MembershipRole_MEMBERSHIP_ROLE_MEMBER:
+		return store.MembershipRoleMember, nil
+	default:
+		return "", fmt.Errorf("invalid membership role: %v", role)
+	}
+}
+
+func toStoreMembershipStatus(status organizationsv1.MembershipStatus) *store.MembershipStatus {
+	switch status {
+	case organizationsv1.MembershipStatus_MEMBERSHIP_STATUS_PENDING:
+		value := store.MembershipStatusPending
+		return &value
+	case organizationsv1.MembershipStatus_MEMBERSHIP_STATUS_ACTIVE:
+		value := store.MembershipStatusActive
+		return &value
+	default:
+		return nil
+	}
+}
+
+func toProtoMembershipRole(role store.MembershipRole) organizationsv1.MembershipRole {
+	switch role {
+	case store.MembershipRoleOwner:
+		return organizationsv1.MembershipRole_MEMBERSHIP_ROLE_OWNER
+	case store.MembershipRoleMember:
+		return organizationsv1.MembershipRole_MEMBERSHIP_ROLE_MEMBER
+	default:
+		panic(fmt.Sprintf("unexpected membership role: %q", role))
+	}
+}
+
+func toProtoMembershipStatus(status store.MembershipStatus) organizationsv1.MembershipStatus {
+	switch status {
+	case store.MembershipStatusPending:
+		return organizationsv1.MembershipStatus_MEMBERSHIP_STATUS_PENDING
+	case store.MembershipStatusActive:
+		return organizationsv1.MembershipStatus_MEMBERSHIP_STATUS_ACTIVE
+	default:
+		panic(fmt.Sprintf("unexpected membership status: %q", status))
+	}
+}
+
+func toProtoMembership(membership store.Membership) *organizationsv1.Membership {
+	var expiresAt *timestamppb.Timestamp
+	if membership.ExpiresAt != nil {
+		expiresAt = timestamppb.New(*membership.ExpiresAt)
+	}
+	return &organizationsv1.Membership{
+		Id:             membership.ID.String(),
+		OrganizationId: membership.OrganizationID.String(),
+		IdentityId:     membership.IdentityID.String(),
+		Role:           toProtoMembershipRole(membership.Role),
+		Status:         toProtoMembershipStatus(membership.Status),
+		ExpiresAt:      expiresAt,
+		CreatedAt:      timestamppb.New(membership.CreatedAt),
+		UpdatedAt:      timestamppb.New(membership.UpdatedAt),
 	}
 }

--- a/internal/server/membership.go
+++ b/internal/server/membership.go
@@ -171,14 +171,14 @@ func (s *Server) RemoveMembership(ctx context.Context, req *organizationsv1.Remo
 		return nil, status.Error(codes.PermissionDenied, "missing permission to manage members")
 	}
 
-	if err := s.store.DeleteMembership(ctx, membership.ID); err != nil {
-		return nil, toStatusError(err)
-	}
-
 	if membership.Status == store.MembershipStatusActive {
 		if err := s.deleteTuple(ctx, membership.IdentityID, string(membership.Role), membership.OrganizationID); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to delete membership tuple: %v", err)
 		}
+	}
+
+	if err := s.store.DeleteMembership(ctx, membership.ID); err != nil {
+		return nil, toStatusError(err)
 	}
 
 	return &organizationsv1.RemoveMembershipResponse{}, nil

--- a/internal/server/membership.go
+++ b/internal/server/membership.go
@@ -1,0 +1,316 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
+	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	"github.com/agynio/organizations/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) CreateMembership(ctx context.Context, req *organizationsv1.CreateMembershipRequest) (*organizationsv1.CreateMembershipResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	identityID, err := parseUUID(req.GetIdentityId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
+	}
+	role, err := toStoreMembershipRole(req.GetRole())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "role: %v", err)
+	}
+
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		if err := req.ExpiresAt.CheckValid(); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "expires_at: %v", err)
+		}
+		value := req.ExpiresAt.AsTime()
+		expiresAt = &value
+	}
+
+	if err := s.ensureIdentityExists(ctx, identityID); err != nil {
+		return nil, err
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_add_member", organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	statusValue := store.MembershipStatusPending
+	if allowed {
+		statusValue = store.MembershipStatusActive
+	} else {
+		invited, err := s.checkPermission(ctx, callerID, "can_invite", organizationID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+		}
+		if !invited {
+			return nil, status.Error(codes.PermissionDenied, "missing permission to add or invite members")
+		}
+	}
+
+	membership, err := s.store.CreateMembership(ctx, store.MembershipInput{
+		OrganizationID: organizationID,
+		IdentityID:     identityID,
+		Role:           role,
+		Status:         statusValue,
+		ExpiresAt:      expiresAt,
+	})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if membership.Status == store.MembershipStatusActive {
+		if err := s.writeTuple(ctx, membership.IdentityID, string(membership.Role), membership.OrganizationID); err != nil {
+			_ = s.store.DeleteMembership(ctx, membership.ID)
+			return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
+		}
+	}
+
+	return &organizationsv1.CreateMembershipResponse{Membership: toProtoMembership(membership)}, nil
+}
+
+func (s *Server) AcceptMembership(ctx context.Context, req *organizationsv1.AcceptMembershipRequest) (*organizationsv1.AcceptMembershipResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	membershipID, err := parseUUID(req.GetMembershipId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "membership_id: %v", err)
+	}
+
+	membership, err := s.store.GetMembership(ctx, membershipID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if membership.IdentityID != callerID {
+		return nil, status.Error(codes.PermissionDenied, "membership belongs to a different identity")
+	}
+	if membership.Status != store.MembershipStatusPending {
+		return nil, status.Error(codes.FailedPrecondition, "membership is not pending")
+	}
+
+	updated, err := s.store.UpdateMembershipStatus(ctx, membership.ID, store.MembershipStatusActive)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if err := s.writeTuple(ctx, updated.IdentityID, string(updated.Role), updated.OrganizationID); err != nil {
+		_, _ = s.store.UpdateMembershipStatus(ctx, updated.ID, store.MembershipStatusPending)
+		return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
+	}
+
+	return &organizationsv1.AcceptMembershipResponse{Membership: toProtoMembership(updated)}, nil
+}
+
+func (s *Server) DeclineMembership(ctx context.Context, req *organizationsv1.DeclineMembershipRequest) (*organizationsv1.DeclineMembershipResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	membershipID, err := parseUUID(req.GetMembershipId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "membership_id: %v", err)
+	}
+
+	membership, err := s.store.GetMembership(ctx, membershipID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if membership.IdentityID != callerID {
+		return nil, status.Error(codes.PermissionDenied, "membership belongs to a different identity")
+	}
+	if membership.Status != store.MembershipStatusPending {
+		return nil, status.Error(codes.FailedPrecondition, "membership is not pending")
+	}
+
+	if err := s.store.DeleteMembership(ctx, membership.ID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &organizationsv1.DeclineMembershipResponse{}, nil
+}
+
+func (s *Server) RemoveMembership(ctx context.Context, req *organizationsv1.RemoveMembershipRequest) (*organizationsv1.RemoveMembershipResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	membershipID, err := parseUUID(req.GetMembershipId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "membership_id: %v", err)
+	}
+
+	membership, err := s.store.GetMembership(ctx, membershipID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_manage_members", membership.OrganizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to manage members")
+	}
+
+	if err := s.store.DeleteMembership(ctx, membership.ID); err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if membership.Status == store.MembershipStatusActive {
+		if err := s.deleteTuple(ctx, membership.IdentityID, string(membership.Role), membership.OrganizationID); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to delete membership tuple: %v", err)
+		}
+	}
+
+	return &organizationsv1.RemoveMembershipResponse{}, nil
+}
+
+func (s *Server) UpdateMembershipRole(ctx context.Context, req *organizationsv1.UpdateMembershipRoleRequest) (*organizationsv1.UpdateMembershipRoleResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	membershipID, err := parseUUID(req.GetMembershipId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "membership_id: %v", err)
+	}
+
+	role, err := toStoreMembershipRole(req.GetRole())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "role: %v", err)
+	}
+
+	membership, err := s.store.GetMembership(ctx, membershipID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_manage_members", membership.OrganizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to manage members")
+	}
+
+	updated, err := s.store.UpdateMembershipRole(ctx, membership.ID, role)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	if updated.Status == store.MembershipStatusActive {
+		_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+			Writes: []*authorizationv1.TupleKey{
+				{
+					User:     identityObjectPrefix + updated.IdentityID.String(),
+					Relation: string(updated.Role),
+					Object:   organizationObjectPrefix + updated.OrganizationID.String(),
+				},
+			},
+			Deletes: []*authorizationv1.TupleKey{
+				{
+					User:     identityObjectPrefix + membership.IdentityID.String(),
+					Relation: string(membership.Role),
+					Object:   organizationObjectPrefix + membership.OrganizationID.String(),
+				},
+			},
+		})
+		if err != nil {
+			_, _ = s.store.UpdateMembershipRole(ctx, membership.ID, membership.Role)
+			return nil, status.Errorf(codes.Internal, "failed to update membership tuple: %v", err)
+		}
+	}
+
+	return &organizationsv1.UpdateMembershipRoleResponse{Membership: toProtoMembership(updated)}, nil
+}
+
+func (s *Server) ListMembers(ctx context.Context, req *organizationsv1.ListMembersRequest) (*organizationsv1.ListMembersResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+
+	allowed, err := s.checkPermission(ctx, callerID, "can_manage_members", organizationID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to manage members")
+	}
+
+	cursor, err := decodePageCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+
+	result, err := s.store.ListMemberships(ctx, store.MembershipFilter{
+		OrganizationID: &organizationID,
+		Status:         toStoreMembershipStatus(req.GetStatus()),
+	}, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	memberships, nextToken := mapListResult(result.Memberships, result.NextCursor, toProtoMembership)
+	return &organizationsv1.ListMembersResponse{Memberships: memberships, NextPageToken: nextToken}, nil
+}
+
+func (s *Server) ListMyMemberships(ctx context.Context, req *organizationsv1.ListMyMembershipsRequest) (*organizationsv1.ListMyMembershipsResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	cursor, err := decodePageCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+
+	result, err := s.store.ListMemberships(ctx, store.MembershipFilter{
+		IdentityID: &callerID,
+		Status:     toStoreMembershipStatus(req.GetStatus()),
+	}, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	memberships, nextToken := mapListResult(result.Memberships, result.NextCursor, toProtoMembership)
+	return &organizationsv1.ListMyMembershipsResponse{Memberships: memberships, NextPageToken: nextToken}, nil
+}
+
+func (s *Server) ensureIdentityExists(ctx context.Context, identityID uuid.UUID) error {
+	_, err := s.identityClient.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: identityID.String()})
+	if err == nil {
+		return nil
+	}
+	statusErr, ok := status.FromError(err)
+	if ok && statusErr.Code() == codes.NotFound {
+		return status.Error(codes.FailedPrecondition, "identity not found")
+	}
+	return status.Errorf(codes.Internal, "identity lookup failed: %v", err)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,16 +99,7 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 		return nil, toStatusError(err)
 	}
 
-	_, err = s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
-		Writes: []*authorizationv1.TupleKey{
-			{
-				User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
-				Relation: "owner",
-				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organization.ID.String()),
-			},
-		},
-	})
-	if err != nil {
+	if err := s.writeTuple(ctx, identityID, "owner", organization.ID); err != nil {
 		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, status.Errorf(codes.Internal, "failed to write ownership tuple: %v", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
+	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
 	"github.com/agynio/organizations/internal/store"
 	"github.com/google/uuid"
@@ -24,10 +25,15 @@ type Server struct {
 	organizationsv1.UnimplementedOrganizationsServiceServer
 	store               *store.Store
 	authorizationClient authorizationv1.AuthorizationServiceClient
+	identityClient      identityv1.IdentityServiceClient
 }
 
-func New(store *store.Store, authorizationClient authorizationv1.AuthorizationServiceClient) *Server {
-	return &Server{store: store, authorizationClient: authorizationClient}
+func New(
+	store *store.Store,
+	authorizationClient authorizationv1.AuthorizationServiceClient,
+	identityClient identityv1.IdentityServiceClient,
+) *Server {
+	return &Server{store: store, authorizationClient: authorizationClient, identityClient: identityClient}
 }
 
 func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
@@ -40,6 +46,46 @@ func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 		return uuid.Nil, fmt.Errorf("x-identity-id not found in metadata")
 	}
 	return uuid.Parse(values[0])
+}
+
+func (s *Server) checkPermission(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) (bool, error) {
+	response, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+			Relation: relation,
+			Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return response.GetAllowed(), nil
+}
+
+func (s *Server) writeTuple(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) error {
+	_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+		Writes: []*authorizationv1.TupleKey{
+			{
+				User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+				Relation: relation,
+				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+			},
+		},
+	})
+	return err
+}
+
+func (s *Server) deleteTuple(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) error {
+	_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+		Deletes: []*authorizationv1.TupleKey{
+			{
+				User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+				Relation: relation,
+				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+			},
+		},
+	})
+	return err
 }
 
 func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest) (*organizationsv1.CreateOrganizationResponse, error) {

--- a/internal/store/errors.go
+++ b/internal/store/errors.go
@@ -1,6 +1,11 @@
 package store
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
 
 type NotFoundError struct {
 	Resource string
@@ -36,4 +41,20 @@ func AlreadyExists(resource string) error {
 
 func ForeignKeyViolation(resource string) error {
 	return &ForeignKeyViolationError{Resource: resource}
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "23505"
+}
+
+func isForeignKeyViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) {
+		return false
+	}
+	return pgErr.Code == "23503"
 }

--- a/internal/store/membership.go
+++ b/internal/store/membership.go
@@ -1,0 +1,146 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const membershipColumns = `id, organization_id, identity_id, role, status, expires_at, created_at, updated_at`
+
+func scanMembership(row pgx.Row) (Membership, error) {
+	var (
+		membership Membership
+		expiresAt  pgtype.Timestamptz
+	)
+	if err := row.Scan(
+		&membership.ID,
+		&membership.OrganizationID,
+		&membership.IdentityID,
+		&membership.Role,
+		&membership.Status,
+		&expiresAt,
+		&membership.CreatedAt,
+		&membership.UpdatedAt,
+	); err != nil {
+		return Membership{}, err
+	}
+	if expiresAt.Valid {
+		membership.ExpiresAt = &expiresAt.Time
+	}
+	return membership, nil
+}
+
+func (s *Store) CreateMembership(ctx context.Context, input MembershipInput) (Membership, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`INSERT INTO memberships (organization_id, identity_id, role, status, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING %s`, membershipColumns),
+		input.OrganizationID,
+		input.IdentityID,
+		input.Role,
+		input.Status,
+		input.ExpiresAt,
+	)
+	membership, err := scanMembership(row)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return Membership{}, AlreadyExists("membership")
+		}
+		if isForeignKeyViolation(err) {
+			return Membership{}, ForeignKeyViolation("membership")
+		}
+		return Membership{}, err
+	}
+	return membership, nil
+}
+
+func (s *Store) GetMembership(ctx context.Context, id uuid.UUID) (Membership, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM memberships WHERE id = $1`, membershipColumns),
+		id,
+	)
+	membership, err := scanMembership(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Membership{}, NotFound("membership")
+		}
+		return Membership{}, err
+	}
+	return membership, nil
+}
+
+func (s *Store) UpdateMembershipStatus(ctx context.Context, id uuid.UUID, status MembershipStatus) (Membership, error) {
+	builder := updateBuilder{}
+	builder.add("status", status)
+	query, args := builder.build("memberships", membershipColumns, id)
+	row := s.pool.QueryRow(ctx, query, args...)
+	membership, err := scanMembership(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Membership{}, NotFound("membership")
+		}
+		return Membership{}, err
+	}
+	return membership, nil
+}
+
+func (s *Store) UpdateMembershipRole(ctx context.Context, id uuid.UUID, role MembershipRole) (Membership, error) {
+	builder := updateBuilder{}
+	builder.add("role", role)
+	query, args := builder.build("memberships", membershipColumns, id)
+	row := s.pool.QueryRow(ctx, query, args...)
+	membership, err := scanMembership(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Membership{}, NotFound("membership")
+		}
+		return Membership{}, err
+	}
+	return membership, nil
+}
+
+func (s *Store) DeleteMembership(ctx context.Context, id uuid.UUID) error {
+	result, err := s.pool.Exec(ctx, `DELETE FROM memberships WHERE id = $1`, id)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return NotFound("membership")
+	}
+	return nil
+}
+
+func (s *Store) ListMemberships(ctx context.Context, filter MembershipFilter, pageSize int32, cursor *PageCursor) (MembershipListResult, error) {
+	var (
+		clauses []string
+		args    []any
+	)
+	if filter.OrganizationID != nil {
+		clauses, args = appendClause(clauses, args, "organization_id = $%d", *filter.OrganizationID)
+	}
+	if filter.IdentityID != nil {
+		clauses, args = appendClause(clauses, args, "identity_id = $%d", *filter.IdentityID)
+	}
+	if filter.Status != nil {
+		clauses, args = appendClause(clauses, args, "status = $%d", *filter.Status)
+	}
+
+	memberships, nextCursor, err := listEntities(ctx, s.pool,
+		fmt.Sprintf("SELECT %s FROM memberships", membershipColumns),
+		clauses,
+		args,
+		cursor,
+		pageSize,
+		scanMembership,
+		func(membership Membership) uuid.UUID { return membership.ID },
+	)
+	if err != nil {
+		return MembershipListResult{}, err
+	}
+	return MembershipListResult{Memberships: memberships, NextCursor: nextCursor}, nil
+}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -29,5 +29,49 @@ type PageCursor struct {
 
 type OrganizationListResult struct {
 	Organizations []Organization
-	NextCursor *PageCursor
+	NextCursor    *PageCursor
+}
+
+type MembershipRole string
+
+const (
+	MembershipRoleOwner  MembershipRole = "owner"
+	MembershipRoleMember MembershipRole = "member"
+)
+
+type MembershipStatus string
+
+const (
+	MembershipStatusPending MembershipStatus = "pending"
+	MembershipStatusActive  MembershipStatus = "active"
+)
+
+type Membership struct {
+	ID             uuid.UUID
+	OrganizationID uuid.UUID
+	IdentityID     uuid.UUID
+	Role           MembershipRole
+	Status         MembershipStatus
+	ExpiresAt      *time.Time
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+type MembershipInput struct {
+	OrganizationID uuid.UUID
+	IdentityID     uuid.UUID
+	Role           MembershipRole
+	Status         MembershipStatus
+	ExpiresAt      *time.Time
+}
+
+type MembershipFilter struct {
+	OrganizationID *uuid.UUID
+	IdentityID     *uuid.UUID
+	Status         *MembershipStatus
+}
+
+type MembershipListResult struct {
+	Memberships []Membership
+	NextCursor  *PageCursor
 }

--- a/migrations/0003_memberships.sql
+++ b/migrations/0003_memberships.sql
@@ -1,0 +1,16 @@
+CREATE TYPE membership_role AS ENUM ('owner', 'member');
+CREATE TYPE membership_status AS ENUM ('pending', 'active');
+
+CREATE TABLE memberships (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    identity_id     UUID NOT NULL,
+    role            membership_role NOT NULL,
+    status          membership_status NOT NULL,
+    expires_at      TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (organization_id, identity_id)
+);
+
+CREATE INDEX idx_memberships_identity_id ON memberships (identity_id);


### PR DESCRIPTION
## Summary
- add memberships migration, store types, and data access
- wire identity client/config and add membership RPC handlers/converters
- update buf generation and helm values for identity address

## Testing
- go vet ./...
- go test ./...

Relates to #12