### PR TITLE
feat: link orgs to cluster access

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,32 +2,38 @@ version: v2beta1
 
 vars:
   ORGANIZATIONS_NAMESPACE: platform
+  ORGANIZATIONS_ARGOCD_APP: tenants
+  ORGANIZATIONS_DEPLOYMENT_NAME: tenants
+  ORGANIZATIONS_SERVICE_NAME: tenants
+  ORGANIZATIONS_RELEASE_NAME: tenants
+  ORGANIZATIONS_APP_NAME: organizations
+  ORGANIZATIONS_CONTAINER_NAME: organizations
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
-    if kubectl get application organizations -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for organizations..."
-      kubectl patch application organizations -n argocd \
+    if kubectl get application ${ORGANIZATIONS_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
+      echo "Disabling ArgoCD auto-sync for ${ORGANIZATIONS_ARGOCD_APP}..."
+      kubectl patch application ${ORGANIZATIONS_ARGOCD_APP} -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":null}}}'
       echo "ArgoCD auto-sync disabled."
     else
-      echo "WARNING: ArgoCD Application 'organizations' not found in argocd namespace."
+      echo "WARNING: ArgoCD Application '${ORGANIZATIONS_ARGOCD_APP}' not found in argocd namespace."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application organizations -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for organizations..."
-      kubectl patch application organizations -n argocd \
+    if kubectl get application ${ORGANIZATIONS_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
+      echo "Re-enabling ArgoCD auto-sync for ${ORGANIZATIONS_ARGOCD_APP}..."
+      kubectl patch application ${ORGANIZATIONS_ARGOCD_APP} -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
       echo "ArgoCD auto-sync restored."
     else
-      echo "WARNING: ArgoCD Application 'organizations' not found in argocd namespace."
+      echo "WARNING: ArgoCD Application '${ORGANIZATIONS_ARGOCD_APP}' not found in argocd namespace."
     fi
   patch_deployment: |-
-    echo "Patching organizations deployment for DevSpace..."
-    kubectl patch deployment organizations -n ${ORGANIZATIONS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    echo "Patching ${ORGANIZATIONS_DEPLOYMENT_NAME} deployment for DevSpace..."
+    kubectl patch deployment ${ORGANIZATIONS_DEPLOYMENT_NAME} -n ${ORGANIZATIONS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -93,7 +99,7 @@ deployments:
           - image: ${E2E_IMAGE}
             env:
               - name: ORGANIZATIONS_ADDR
-                value: "organizations:50051"
+                value: "${ORGANIZATIONS_SERVICE_NAME}:50051"
             volumeMounts:
               - containerPath: /opt/app/data
                 volume:
@@ -121,10 +127,10 @@ pipelines:
         start_dev --disable-pod-replace organizations
       else
         start_dev --disable-pod-replace organizations
-        echo "Waiting for organizations to be healthy on :50051..."
+        echo "Waiting for ${ORGANIZATIONS_SERVICE_NAME} to be healthy on :50051..."
         healthy=false
         for i in $(seq 1 60); do
-          if exec_container --label-selector=app.kubernetes.io/name=organizations -n ${ORGANIZATIONS_NAMESPACE} -- bash -c 'nc -z localhost 50051 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/50051) >/dev/null 2>&1'; then
+          if exec_container --label-selector=app.kubernetes.io/name=${ORGANIZATIONS_APP_NAME},app.kubernetes.io/instance=${ORGANIZATIONS_RELEASE_NAME} -n ${ORGANIZATIONS_NAMESPACE} -- bash -c 'nc -z localhost 50051 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/50051) >/dev/null 2>&1'; then
             healthy=true
             break
           fi
@@ -143,8 +149,8 @@ pipelines:
       disable_argocd_sync
 
       # Update the deployment to use the freshly-built image (built and loaded in CI)
-      kubectl set image deployment/organizations organizations=ghcr.io/agynio/organizations:e2e-test -n ${ORGANIZATIONS_NAMESPACE}
-      kubectl rollout status deployment/organizations -n ${ORGANIZATIONS_NAMESPACE} --timeout=120s
+      kubectl set image deployment/${ORGANIZATIONS_DEPLOYMENT_NAME} ${ORGANIZATIONS_CONTAINER_NAME}=ghcr.io/agynio/organizations:e2e-test -n ${ORGANIZATIONS_NAMESPACE}
+      kubectl rollout status deployment/${ORGANIZATIONS_DEPLOYMENT_NAME} -n ${ORGANIZATIONS_NAMESPACE} --timeout=120s
 
       create_deployments e2e-runner
       start_dev e2e-runner &
@@ -197,8 +203,8 @@ dev:
   organizations:
     namespace: ${ORGANIZATIONS_NAMESPACE}
     labelSelector:
-      app.kubernetes.io/name: organizations
-      app.kubernetes.io/instance: organizations
+      app.kubernetes.io/name: ${ORGANIZATIONS_APP_NAME}
+      app.kubernetes.io/instance: ${ORGANIZATIONS_RELEASE_NAME}
     containers:
       organizations:
         container: organizations

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,39 +1,35 @@
 version: v2beta1
 
+# NOTE: Bootstrap deploys OrganizationsService as "tenants" (fullnameOverride + ArgoCD app).
+# Keep DevSpace pointing at tenants until bootstrap renames it back.
 vars:
   ORGANIZATIONS_NAMESPACE: platform
-  ORGANIZATIONS_ARGOCD_APP: tenants
-  ORGANIZATIONS_DEPLOYMENT_NAME: tenants
-  ORGANIZATIONS_SERVICE_NAME: tenants
-  ORGANIZATIONS_RELEASE_NAME: tenants
-  ORGANIZATIONS_APP_NAME: organizations
-  ORGANIZATIONS_CONTAINER_NAME: organizations
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
-    if kubectl get application ${ORGANIZATIONS_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for ${ORGANIZATIONS_ARGOCD_APP}..."
-      kubectl patch application ${ORGANIZATIONS_ARGOCD_APP} -n argocd \
+    if kubectl get application tenants -n argocd >/dev/null 2>&1; then
+      echo "Disabling ArgoCD auto-sync for tenants..."
+      kubectl patch application tenants -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":null}}}'
       echo "ArgoCD auto-sync disabled."
     else
-      echo "WARNING: ArgoCD Application '${ORGANIZATIONS_ARGOCD_APP}' not found in argocd namespace."
+      echo "WARNING: ArgoCD Application 'tenants' not found in argocd namespace."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application ${ORGANIZATIONS_ARGOCD_APP} -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for ${ORGANIZATIONS_ARGOCD_APP}..."
-      kubectl patch application ${ORGANIZATIONS_ARGOCD_APP} -n argocd \
+    if kubectl get application tenants -n argocd >/dev/null 2>&1; then
+      echo "Re-enabling ArgoCD auto-sync for tenants..."
+      kubectl patch application tenants -n argocd \
         --type merge \
         -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
       echo "ArgoCD auto-sync restored."
     else
-      echo "WARNING: ArgoCD Application '${ORGANIZATIONS_ARGOCD_APP}' not found in argocd namespace."
+      echo "WARNING: ArgoCD Application 'tenants' not found in argocd namespace."
     fi
   patch_deployment: |-
-    echo "Patching ${ORGANIZATIONS_DEPLOYMENT_NAME} deployment for DevSpace..."
-    kubectl patch deployment ${ORGANIZATIONS_DEPLOYMENT_NAME} -n ${ORGANIZATIONS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    echo "Patching tenants deployment for DevSpace..."
+    kubectl patch deployment tenants -n ${ORGANIZATIONS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:
@@ -99,7 +95,7 @@ deployments:
           - image: ${E2E_IMAGE}
             env:
               - name: ORGANIZATIONS_ADDR
-                value: "${ORGANIZATIONS_SERVICE_NAME}:50051"
+                value: "tenants:50051"
             volumeMounts:
               - containerPath: /opt/app/data
                 volume:
@@ -127,10 +123,10 @@ pipelines:
         start_dev --disable-pod-replace organizations
       else
         start_dev --disable-pod-replace organizations
-        echo "Waiting for ${ORGANIZATIONS_SERVICE_NAME} to be healthy on :50051..."
+        echo "Waiting for tenants to be healthy on :50051..."
         healthy=false
         for i in $(seq 1 60); do
-          if exec_container --label-selector=app.kubernetes.io/name=${ORGANIZATIONS_APP_NAME},app.kubernetes.io/instance=${ORGANIZATIONS_RELEASE_NAME} -n ${ORGANIZATIONS_NAMESPACE} -- bash -c 'nc -z localhost 50051 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/50051) >/dev/null 2>&1'; then
+          if exec_container --label-selector=app.kubernetes.io/name=organizations,app.kubernetes.io/instance=tenants -n ${ORGANIZATIONS_NAMESPACE} -- bash -c 'nc -z localhost 50051 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/50051) >/dev/null 2>&1'; then
             healthy=true
             break
           fi
@@ -149,8 +145,8 @@ pipelines:
       disable_argocd_sync
 
       # Update the deployment to use the freshly-built image (built and loaded in CI)
-      kubectl set image deployment/${ORGANIZATIONS_DEPLOYMENT_NAME} ${ORGANIZATIONS_CONTAINER_NAME}=ghcr.io/agynio/organizations:e2e-test -n ${ORGANIZATIONS_NAMESPACE}
-      kubectl rollout status deployment/${ORGANIZATIONS_DEPLOYMENT_NAME} -n ${ORGANIZATIONS_NAMESPACE} --timeout=120s
+      kubectl set image deployment/tenants organizations=ghcr.io/agynio/organizations:e2e-test -n ${ORGANIZATIONS_NAMESPACE}
+      kubectl rollout status deployment/tenants -n ${ORGANIZATIONS_NAMESPACE} --timeout=120s
 
       create_deployments e2e-runner
       start_dev e2e-runner &
@@ -203,8 +199,8 @@ dev:
   organizations:
     namespace: ${ORGANIZATIONS_NAMESPACE}
     labelSelector:
-      app.kubernetes.io/name: ${ORGANIZATIONS_APP_NAME}
-      app.kubernetes.io/instance: ${ORGANIZATIONS_RELEASE_NAME}
+      app.kubernetes.io/name: organizations
+      app.kubernetes.io/instance: tenants
     containers:
       organizations:
         container: organizations

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 const (
 	organizationObjectPrefix = "organization:"
 	identityObjectPrefix     = "identity:"
+	clusterObject            = "cluster:global"
 )
 
 type Server struct {
@@ -88,6 +89,32 @@ func (s *Server) deleteTuple(ctx context.Context, identityID uuid.UUID, relation
 	return err
 }
 
+func (s *Server) writeClusterTuple(ctx context.Context, relation string, organizationID uuid.UUID) error {
+	_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+		Writes: []*authorizationv1.TupleKey{
+			{
+				User:     clusterObject,
+				Relation: relation,
+				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+			},
+		},
+	})
+	return err
+}
+
+func (s *Server) deleteClusterTuple(ctx context.Context, relation string, organizationID uuid.UUID) error {
+	_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
+		Deletes: []*authorizationv1.TupleKey{
+			{
+				User:     clusterObject,
+				Relation: relation,
+				Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+			},
+		},
+	})
+	return err
+}
+
 func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.CreateOrganizationRequest) (*organizationsv1.CreateOrganizationResponse, error) {
 	identityID, err := identityIDFromContext(ctx)
 	if err != nil {
@@ -99,7 +126,13 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 		return nil, toStatusError(err)
 	}
 
+	if err := s.writeClusterTuple(ctx, "cluster", organization.ID); err != nil {
+		_ = s.store.DeleteOrganization(ctx, organization.ID)
+		return nil, status.Errorf(codes.Internal, "failed to write cluster tuple: %v", err)
+	}
+
 	if err := s.writeTuple(ctx, identityID, "owner", organization.ID); err != nil {
+		_ = s.deleteClusterTuple(ctx, "cluster", organization.ID)
 		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, status.Errorf(codes.Internal, "failed to write ownership tuple: %v", err)
 	}
@@ -112,6 +145,7 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 	})
 	if err != nil {
 		_ = s.deleteTuple(ctx, identityID, "owner", organization.ID)
+		_ = s.deleteClusterTuple(ctx, "cluster", organization.ID)
 		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, toStatusError(err)
 	}
@@ -182,7 +216,7 @@ func (s *Server) ListAccessibleOrganizations(ctx context.Context, req *organizat
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
 	}
 
-	authResponse, err := s.authorizationClient.ListObjects(ctx, &authorizationv1.ListObjectsRequest{
+	memberResponse, err := s.authorizationClient.ListObjects(ctx, &authorizationv1.ListObjectsRequest{
 		Type:     "organization",
 		Relation: "member",
 		User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
@@ -190,12 +224,28 @@ func (s *Server) ListAccessibleOrganizations(ctx context.Context, req *organizat
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "authorization list objects: %v", err)
 	}
-	if len(authResponse.Objects) == 0 {
+	adminResponse, err := s.authorizationClient.ListObjects(ctx, &authorizationv1.ListObjectsRequest{
+		Type:     "organization",
+		Relation: "can_add_member",
+		User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+	})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization list objects: %v", err)
+	}
+
+	objects := make(map[string]struct{}, len(memberResponse.Objects)+len(adminResponse.Objects))
+	for _, object := range memberResponse.Objects {
+		objects[object] = struct{}{}
+	}
+	for _, object := range adminResponse.Objects {
+		objects[object] = struct{}{}
+	}
+	if len(objects) == 0 {
 		return &organizationsv1.ListAccessibleOrganizationsResponse{Organizations: []*organizationsv1.Organization{}}, nil
 	}
 
-	organizationIDs := make([]uuid.UUID, 0, len(authResponse.Objects))
-	for _, object := range authResponse.Objects {
+	organizationIDs := make([]uuid.UUID, 0, len(objects))
+	for object := range objects {
 		organizationID, err := parseOrganizationObject(object)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "authorization object %q: %v", object, err)


### PR DESCRIPTION
## Summary
- write cluster:global#cluster@organization tuples on org creation
- rollback cluster tuples on failures
- union member + can_add_member for accessible org listing

## Context
Bootstrap still deploys OrganizationsService under the tenants release (fullnameOverride + ArgoCD app name). DevSpace e2e needs to point at those tenant-scoped resource names (deployment/service/labels) so CI can find and update the workload. Once bootstrap renames the release back to organizations, we can revert the tenants hardcoding here.

## Testing
- buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
- go vet ./...
- go test ./...
- go build ./...

Refs #67