### PR TITLE
feat(organizations): add org nickname support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/users/v1
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ COPY buf.gen.yaml ./
 RUN buf generate buf.build/agynio/api \
     --path agynio/api/organizations/v1 \
     --path agynio/api/authorization/v1 \
-    --path agynio/api/identity/v1
+    --path agynio/api/identity/v1 \
+    --path agynio/api/users/v1
 
 COPY . .
 

--- a/cmd/organizations-service/main.go
+++ b/cmd/organizations-service/main.go
@@ -13,6 +13,7 @@ import (
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	usersv1 "github.com/agynio/organizations/.gen/go/agynio/api/users/v1"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -64,11 +65,18 @@ func run() error {
 	}
 	defer identityConn.Close()
 
+	usersConn, err := grpc.NewClient(cfg.UsersAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connect to users: %w", err)
+	}
+	defer usersConn.Close()
+
 	grpcServer := grpc.NewServer()
 	serverInstance := server.New(
 		store.New(pool),
 		authorizationv1.NewAuthorizationServiceClient(authConn),
 		identityv1.NewIdentityServiceClient(identityConn),
+		usersv1.NewUsersServiceClient(usersConn),
 	)
 	organizationsv1.RegisterOrganizationsServiceServer(grpcServer, serverInstance)
 

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -51,7 +51,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
+                  buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/users/v1
                   exec go run ./cmd/organizations-service
               volumeMounts:
                 - name: data
@@ -175,7 +175,7 @@ pipelines:
         -- bash -c '
           set -eu
           cd /opt/app/data
-          buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
+          buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/users/v1
           go test -v -count=1 -tags e2e ./test/e2e/
         '
       EXIT_CODE=$?

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	DatabaseURL          string
 	AuthorizationAddress string
 	IdentityAddress      string
+	UsersAddress         string
 }
 
 func FromEnv() (Config, error) {
@@ -29,6 +30,10 @@ func FromEnv() (Config, error) {
 	cfg.IdentityAddress = os.Getenv("IDENTITY_ADDRESS")
 	if cfg.IdentityAddress == "" {
 		cfg.IdentityAddress = "identity:50051"
+	}
+	cfg.UsersAddress = os.Getenv("USERS_ADDRESS")
+	if cfg.UsersAddress == "" {
+		cfg.UsersAddress = "users:50051"
 	}
 	return cfg, nil
 }

--- a/internal/server/membership.go
+++ b/internal/server/membership.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log"
 	"time"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
@@ -80,7 +82,9 @@ func (s *Server) CreateMembership(ctx context.Context, req *organizationsv1.Crea
 			_ = s.store.DeleteMembership(ctx, membership.ID)
 			return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
 		}
-		s.seedDefaultNickname(ctx, membership.OrganizationID, membership.IdentityID)
+		if err := s.seedDefaultNickname(ctx, membership.OrganizationID, membership.IdentityID); err != nil {
+			log.Printf("seed default nickname failed (org=%s identity=%s): %v", membership.OrganizationID, membership.IdentityID, err)
+		}
 	}
 
 	return &organizationsv1.CreateMembershipResponse{Membership: toProtoMembership(membership)}, nil
@@ -117,7 +121,9 @@ func (s *Server) AcceptMembership(ctx context.Context, req *organizationsv1.Acce
 		_, _ = s.store.UpdateMembershipStatus(ctx, updated.ID, store.MembershipStatusPending)
 		return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
 	}
-	s.seedDefaultNickname(ctx, updated.OrganizationID, updated.IdentityID)
+	if err := s.seedDefaultNickname(ctx, updated.OrganizationID, updated.IdentityID); err != nil {
+		log.Printf("seed default nickname failed (org=%s identity=%s): %v", updated.OrganizationID, updated.IdentityID, err)
+	}
 
 	return &organizationsv1.AcceptMembershipResponse{Membership: toProtoMembership(updated)}, nil
 }
@@ -361,18 +367,21 @@ func (s *Server) ensureIdentityExists(ctx context.Context, identityID uuid.UUID)
 	return status.Errorf(codes.Internal, "identity lookup failed: %v", err)
 }
 
-func (s *Server) seedDefaultNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID) {
+func (s *Server) seedDefaultNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID) error {
 	identityType, err := s.identityClient.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: identityID.String()})
 	if err != nil {
-		return
+		return fmt.Errorf("get identity type: %w", err)
 	}
 	if identityType.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_USER {
-		return
+		return nil
 	}
 
-	username := s.fetchUsername(ctx, identityID)
+	username, err := s.fetchUsername(ctx, identityID)
+	if err != nil {
+		return fmt.Errorf("fetch username: %w", err)
+	}
 	if username == "" {
-		return
+		return nil
 	}
 	_, err = s.identityClient.SetNickname(ctx, &identityv1.SetNicknameRequest{
 		OrganizationId: organizationID.String(),
@@ -381,19 +390,21 @@ func (s *Server) seedDefaultNickname(ctx context.Context, organizationID uuid.UU
 	})
 	if err != nil {
 		if statusErr, ok := status.FromError(err); ok && statusErr.Code() == codes.AlreadyExists {
-			return
+			return nil
 		}
+		return fmt.Errorf("set nickname: %w", err)
 	}
+	return nil
 }
 
-func (s *Server) fetchUsername(ctx context.Context, identityID uuid.UUID) string {
+func (s *Server) fetchUsername(ctx context.Context, identityID uuid.UUID) (string, error) {
 	response, err := s.usersClient.BatchGetUsers(ctx, &usersv1.BatchGetUsersRequest{IdentityIds: []string{identityID.String()}})
 	if err != nil {
-		return ""
+		return "", err
 	}
 	users := response.GetUsers()
 	if len(users) == 0 {
-		return ""
+		return "", nil
 	}
-	return users[0].GetUsername()
+	return users[0].GetUsername(), nil
 }

--- a/internal/server/membership.go
+++ b/internal/server/membership.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 	"errors"
-	"strings"
 	"time"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	usersv1 "github.com/agynio/organizations/.gen/go/agynio/api/users/v1"
 	"github.com/agynio/organizations/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -362,17 +362,38 @@ func (s *Server) ensureIdentityExists(ctx context.Context, identityID uuid.UUID)
 }
 
 func (s *Server) seedDefaultNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID) {
-	nickname := defaultNickname(identityID)
-	if nickname == "" {
+	identityType, err := s.identityClient.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: identityID.String()})
+	if err != nil {
 		return
 	}
-	_, _ = s.identityClient.SetNickname(ctx, &identityv1.SetNicknameRequest{
+	if identityType.GetIdentityType() != identityv1.IdentityType_IDENTITY_TYPE_USER {
+		return
+	}
+
+	username := s.fetchUsername(ctx, identityID)
+	if username == "" {
+		return
+	}
+	_, err = s.identityClient.SetNickname(ctx, &identityv1.SetNicknameRequest{
 		OrganizationId: organizationID.String(),
 		IdentityId:     identityID.String(),
-		Nickname:       nickname,
+		Nickname:       username,
 	})
+	if err != nil {
+		if statusErr, ok := status.FromError(err); ok && statusErr.Code() == codes.AlreadyExists {
+			return
+		}
+	}
 }
 
-func defaultNickname(identityID uuid.UUID) string {
-	return strings.ReplaceAll(identityID.String(), "-", "")
+func (s *Server) fetchUsername(ctx context.Context, identityID uuid.UUID) string {
+	response, err := s.usersClient.BatchGetUsers(ctx, &usersv1.BatchGetUsersRequest{IdentityIds: []string{identityID.String()}})
+	if err != nil {
+		return ""
+	}
+	users := response.GetUsers()
+	if len(users) == 0 {
+		return ""
+	}
+	return users[0].GetUsername()
 }

--- a/internal/server/membership.go
+++ b/internal/server/membership.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
@@ -78,6 +80,7 @@ func (s *Server) CreateMembership(ctx context.Context, req *organizationsv1.Crea
 			_ = s.store.DeleteMembership(ctx, membership.ID)
 			return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
 		}
+		s.seedDefaultNickname(ctx, membership.OrganizationID, membership.IdentityID)
 	}
 
 	return &organizationsv1.CreateMembershipResponse{Membership: toProtoMembership(membership)}, nil
@@ -114,6 +117,7 @@ func (s *Server) AcceptMembership(ctx context.Context, req *organizationsv1.Acce
 		_, _ = s.store.UpdateMembershipStatus(ctx, updated.ID, store.MembershipStatusPending)
 		return nil, status.Errorf(codes.Internal, "failed to write membership tuple: %v", err)
 	}
+	s.seedDefaultNickname(ctx, updated.OrganizationID, updated.IdentityID)
 
 	return &organizationsv1.AcceptMembershipResponse{Membership: toProtoMembership(updated)}, nil
 }
@@ -303,6 +307,48 @@ func (s *Server) ListMyMemberships(ctx context.Context, req *organizationsv1.Lis
 	return &organizationsv1.ListMyMembershipsResponse{Memberships: memberships, NextPageToken: nextToken}, nil
 }
 
+func (s *Server) SetMyOrgNickname(ctx context.Context, req *organizationsv1.SetMyOrgNicknameRequest) (*organizationsv1.SetMyOrgNicknameResponse, error) {
+	callerID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	organizationID, err := parseUUID(req.GetOrganizationId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+	}
+	nickname := req.GetNickname()
+	if nickname == "" {
+		return nil, status.Error(codes.InvalidArgument, "nickname must be provided")
+	}
+
+	membership, err := s.store.GetMembershipByOrganizationIdentity(ctx, organizationID, callerID)
+	if err != nil {
+		var notFound *store.NotFoundError
+		if errors.As(err, &notFound) {
+			return nil, status.Error(codes.PermissionDenied, "active membership required")
+		}
+		return nil, toStatusError(err)
+	}
+	if membership.Status != store.MembershipStatusActive {
+		return nil, status.Error(codes.PermissionDenied, "active membership required")
+	}
+
+	_, err = s.identityClient.SetNickname(ctx, &identityv1.SetNicknameRequest{
+		OrganizationId: organizationID.String(),
+		IdentityId:     callerID.String(),
+		Nickname:       nickname,
+	})
+	if err != nil {
+		if statusErr, ok := status.FromError(err); ok {
+			return nil, status.Error(statusErr.Code(), statusErr.Message())
+		}
+		return nil, status.Errorf(codes.Internal, "set nickname: %v", err)
+	}
+
+	return &organizationsv1.SetMyOrgNicknameResponse{}, nil
+}
+
 func (s *Server) ensureIdentityExists(ctx context.Context, identityID uuid.UUID) error {
 	_, err := s.identityClient.GetIdentityType(ctx, &identityv1.GetIdentityTypeRequest{IdentityId: identityID.String()})
 	if err == nil {
@@ -313,4 +359,20 @@ func (s *Server) ensureIdentityExists(ctx context.Context, identityID uuid.UUID)
 		return status.Error(codes.FailedPrecondition, "identity not found")
 	}
 	return status.Errorf(codes.Internal, "identity lookup failed: %v", err)
+}
+
+func (s *Server) seedDefaultNickname(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID) {
+	nickname := defaultNickname(identityID)
+	if nickname == "" {
+		return
+	}
+	_, _ = s.identityClient.SetNickname(ctx, &identityv1.SetNicknameRequest{
+		OrganizationId: organizationID.String(),
+		IdentityId:     identityID.String(),
+		Nickname:       nickname,
+	})
+}
+
+func defaultNickname(identityID uuid.UUID) string {
+	return strings.ReplaceAll(identityID.String(), "-", "")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
@@ -157,7 +158,9 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, toStatusError(err)
 	}
-	s.seedDefaultNickname(ctx, organization.ID, identityID)
+	if err := s.seedDefaultNickname(ctx, organization.ID, identityID); err != nil {
+		log.Printf("seed default nickname failed (org=%s identity=%s): %v", organization.ID, identityID, err)
+	}
 	return &organizationsv1.CreateOrganizationResponse{Organization: toProtoOrganization(organization)}, nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
 	identityv1 "github.com/agynio/organizations/.gen/go/agynio/api/identity/v1"
 	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	usersv1 "github.com/agynio/organizations/.gen/go/agynio/api/users/v1"
 	"github.com/agynio/organizations/internal/store"
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -27,14 +28,21 @@ type Server struct {
 	store               *store.Store
 	authorizationClient authorizationv1.AuthorizationServiceClient
 	identityClient      identityv1.IdentityServiceClient
+	usersClient         usersv1.UsersServiceClient
 }
 
 func New(
 	store *store.Store,
 	authorizationClient authorizationv1.AuthorizationServiceClient,
 	identityClient identityv1.IdentityServiceClient,
+	usersClient usersv1.UsersServiceClient,
 ) *Server {
-	return &Server{store: store, authorizationClient: authorizationClient, identityClient: identityClient}
+	return &Server{
+		store:               store,
+		authorizationClient: authorizationClient,
+		identityClient:      identityClient,
+		usersClient:         usersClient,
+	}
 }
 
 func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -149,6 +149,7 @@ func (s *Server) CreateOrganization(ctx context.Context, req *organizationsv1.Cr
 		_ = s.store.DeleteOrganization(ctx, organization.ID)
 		return nil, toStatusError(err)
 	}
+	s.seedDefaultNickname(ctx, organization.ID, identityID)
 	return &organizationsv1.CreateOrganizationResponse{Organization: toProtoOrganization(organization)}, nil
 }
 

--- a/internal/store/membership.go
+++ b/internal/store/membership.go
@@ -74,6 +74,22 @@ func (s *Store) GetMembership(ctx context.Context, id uuid.UUID) (Membership, er
 	return membership, nil
 }
 
+func (s *Store) GetMembershipByOrganizationIdentity(ctx context.Context, organizationID uuid.UUID, identityID uuid.UUID) (Membership, error) {
+	row := s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT %s FROM memberships WHERE organization_id = $1 AND identity_id = $2`, membershipColumns),
+		organizationID,
+		identityID,
+	)
+	membership, err := scanMembership(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Membership{}, NotFound("membership")
+		}
+		return Membership{}, err
+	}
+	return membership, nil
+}
+
 func (s *Store) UpdateMembershipStatus(ctx context.Context, id uuid.UUID, status MembershipStatus) (Membership, error) {
 	builder := updateBuilder{}
 	builder.add("status", status)


### PR DESCRIPTION
## Summary
- seed default org nicknames when memberships become active
- enforce active membership authz for SetMyOrgNickname
- add membership lookup helper for org+identity checks

## Testing
- buf generate buf.build/agynio/api:74e093945d7343239e9933d5de061836 --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1
- GOTOOLCHAIN=local go vet ./...
- GOTOOLCHAIN=local go test ./...

Refs #140