### PR TITLE
feat(organizations): gate ListOrganizations

### DIFF
--- a/internal/server/list_organizations_test.go
+++ b/internal/server/list_organizations_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	authorizationv1 "github.com/agynio/organizations/.gen/go/agynio/api/authorization/v1"
+	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	"github.com/agynio/organizations/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const authBufSize = 1024 * 1024
+
+type authCheckServer struct {
+	authorizationv1.UnimplementedAuthorizationServiceServer
+	allowed     bool
+	requestLock sync.Mutex
+	lastRequest *authorizationv1.CheckRequest
+}
+
+func (s *authCheckServer) Check(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+	s.requestLock.Lock()
+	s.lastRequest = req
+	s.requestLock.Unlock()
+	return &authorizationv1.CheckResponse{Allowed: s.allowed}, nil
+}
+
+func setupAuthClient(t *testing.T, allowed bool) (authorizationv1.AuthorizationServiceClient, *authCheckServer, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(authBufSize)
+	grpcServer := grpc.NewServer()
+	authServer := &authCheckServer{allowed: allowed}
+	authorizationv1.RegisterAuthorizationServiceServer(grpcServer, authServer)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		grpcServer.Stop()
+		t.Fatalf("dial bufnet: %v", err)
+	}
+
+	cleanup := func() {
+		_ = conn.Close()
+		grpcServer.Stop()
+	}
+	return authorizationv1.NewAuthorizationServiceClient(conn), authServer, cleanup
+}
+
+func TestListOrganizationsClusterAdmin(t *testing.T) {
+	authClient, authServer, cleanup := setupAuthClient(t, true)
+	defer cleanup()
+
+	identityID := uuid.New()
+	organizationID := uuid.New()
+	createdAt := time.Now().UTC()
+	updatedAt := createdAt.Add(2 * time.Minute)
+	called := false
+
+	server := &Server{
+		authorizationClient: authClient,
+		listOrganizations: func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+			called = true
+			return store.OrganizationListResult{
+				Organizations: []store.Organization{
+					{
+						ID:        organizationID,
+						Name:      "Acme Corp",
+						CreatedAt: createdAt,
+						UpdatedAt: updatedAt,
+					},
+				},
+			}, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	response, err := server.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: 5})
+	if err != nil {
+		t.Fatalf("ListOrganizations returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected listOrganizations to be called")
+	}
+	if len(response.Organizations) != 1 {
+		t.Fatalf("expected 1 organization, got %d", len(response.Organizations))
+	}
+	if response.Organizations[0].GetId() != organizationID.String() {
+		t.Fatalf("expected organization id %s, got %s", organizationID.String(), response.Organizations[0].GetId())
+	}
+
+	authServer.requestLock.Lock()
+	request := authServer.lastRequest
+	authServer.requestLock.Unlock()
+	if request == nil || request.GetTupleKey() == nil {
+		t.Fatal("expected authorization check request")
+	}
+	if request.GetTupleKey().GetObject() != clusterObject {
+		t.Fatalf("expected cluster object %s, got %s", clusterObject, request.GetTupleKey().GetObject())
+	}
+	if request.GetTupleKey().GetRelation() != "admin" {
+		t.Fatalf("expected admin relation, got %s", request.GetTupleKey().GetRelation())
+	}
+	if request.GetTupleKey().GetUser() != identityObjectPrefix+identityID.String() {
+		t.Fatalf("expected user %s, got %s", identityObjectPrefix+identityID.String(), request.GetTupleKey().GetUser())
+	}
+}
+
+func TestListOrganizationsNonAdminDenied(t *testing.T) {
+	authClient, _, cleanup := setupAuthClient(t, false)
+	defer cleanup()
+
+	server := &Server{
+		authorizationClient: authClient,
+		listOrganizations: func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+			t.Fatal("listOrganizations should not be called for non-admin")
+			return store.OrganizationListResult{}, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.New().String()))
+	_, err := server.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: 5})
+	if err == nil {
+		t.Fatal("expected error for non-admin ListOrganizations")
+	}
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected status error, got %v", err)
+	}
+	if statusErr.Code() != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %s", statusErr.Code())
+	}
+}

--- a/internal/server/list_organizations_test.go
+++ b/internal/server/list_organizations_test.go
@@ -146,3 +146,40 @@ func TestListOrganizationsNonAdminDenied(t *testing.T) {
 		t.Fatalf("expected PermissionDenied, got %s", statusErr.Code())
 	}
 }
+
+func TestListOrganizationsNoIdentityAllowed(t *testing.T) {
+	organizationID := uuid.New()
+	createdAt := time.Now().UTC()
+	updatedAt := createdAt.Add(2 * time.Minute)
+	called := false
+
+	server := &Server{
+		listOrganizations: func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+			called = true
+			return store.OrganizationListResult{
+				Organizations: []store.Organization{
+					{
+						ID:        organizationID,
+						Name:      "Acme Corp",
+						CreatedAt: createdAt,
+						UpdatedAt: updatedAt,
+					},
+				},
+			}, nil
+		},
+	}
+
+	response, err := server.ListOrganizations(context.Background(), &organizationsv1.ListOrganizationsRequest{PageSize: 5})
+	if err != nil {
+		t.Fatalf("ListOrganizations returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected listOrganizations to be called")
+	}
+	if len(response.Organizations) != 1 {
+		t.Fatalf("expected 1 organization, got %d", len(response.Organizations))
+	}
+	if response.Organizations[0].GetId() != organizationID.String() {
+		t.Fatalf("expected organization id %s, got %s", organizationID.String(), response.Organizations[0].GetId())
+	}
+}

--- a/internal/server/list_organizations_test.go
+++ b/internal/server/list_organizations_test.go
@@ -147,39 +147,32 @@ func TestListOrganizationsNonAdminDenied(t *testing.T) {
 	}
 }
 
-func TestListOrganizationsNoIdentityAllowed(t *testing.T) {
-	organizationID := uuid.New()
-	createdAt := time.Now().UTC()
-	updatedAt := createdAt.Add(2 * time.Minute)
-	called := false
+func TestListOrganizationsMissingIdentityUnauthenticated(t *testing.T) {
+	tests := map[string]context.Context{
+		"no metadata":    context.Background(),
+		"blank identity": metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", "")),
+	}
 
-	server := &Server{
-		listOrganizations: func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
-			called = true
-			return store.OrganizationListResult{
-				Organizations: []store.Organization{
-					{
-						ID:        organizationID,
-						Name:      "Acme Corp",
-						CreatedAt: createdAt,
-						UpdatedAt: updatedAt,
-					},
+	for name, ctx := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := &Server{
+				listOrganizations: func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+					t.Fatal("listOrganizations should not be called without identity")
+					return store.OrganizationListResult{}, nil
 				},
-			}, nil
-		},
-	}
+			}
 
-	response, err := server.ListOrganizations(context.Background(), &organizationsv1.ListOrganizationsRequest{PageSize: 5})
-	if err != nil {
-		t.Fatalf("ListOrganizations returned error: %v", err)
-	}
-	if !called {
-		t.Fatal("expected listOrganizations to be called")
-	}
-	if len(response.Organizations) != 1 {
-		t.Fatalf("expected 1 organization, got %d", len(response.Organizations))
-	}
-	if response.Organizations[0].GetId() != organizationID.String() {
-		t.Fatalf("expected organization id %s, got %s", organizationID.String(), response.Organizations[0].GetId())
+			_, err := server.ListOrganizations(ctx, &organizationsv1.ListOrganizationsRequest{PageSize: 5})
+			if err == nil {
+				t.Fatal("expected error for missing identity")
+			}
+			statusErr, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("expected status error, got %v", err)
+			}
+			if statusErr.Code() != codes.Unauthenticated {
+				t.Fatalf("expected Unauthenticated, got %s", statusErr.Code())
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,20 +30,25 @@ type Server struct {
 	authorizationClient authorizationv1.AuthorizationServiceClient
 	identityClient      identityv1.IdentityServiceClient
 	usersClient         usersv1.UsersServiceClient
+	listOrganizations   func(context.Context, int32, *store.PageCursor) (store.OrganizationListResult, error)
 }
 
 func New(
-	store *store.Store,
+	organizationStore *store.Store,
 	authorizationClient authorizationv1.AuthorizationServiceClient,
 	identityClient identityv1.IdentityServiceClient,
 	usersClient usersv1.UsersServiceClient,
 ) *Server {
-	return &Server{
-		store:               store,
+	server := &Server{
+		store:               organizationStore,
 		authorizationClient: authorizationClient,
 		identityClient:      identityClient,
 		usersClient:         usersClient,
 	}
+	server.listOrganizations = func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+		return organizationStore.ListOrganizations(ctx, store.OrganizationFilter{}, pageSize, cursor)
+	}
+	return server
 }
 
 func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
@@ -64,6 +69,20 @@ func (s *Server) checkPermission(ctx context.Context, identityID uuid.UUID, rela
 			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
 			Relation: relation,
 			Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return response.GetAllowed(), nil
+}
+
+func (s *Server) isClusterAdmin(ctx context.Context, identityID uuid.UUID) (bool, error) {
+	response, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID.String()),
+			Relation: "admin",
+			Object:   clusterObject,
 		},
 	})
 	if err != nil {
@@ -210,11 +229,30 @@ func (s *Server) DeleteOrganization(ctx context.Context, req *organizationsv1.De
 }
 
 func (s *Server) ListOrganizations(ctx context.Context, req *organizationsv1.ListOrganizationsRequest) (*organizationsv1.ListOrganizationsResponse, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
+	allowed, err := s.isClusterAdmin(ctx, identityID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to list organizations")
+	}
+
 	cursor, err := decodePageCursor(req.GetPageToken())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
 	}
-	result, err := s.store.ListOrganizations(ctx, store.OrganizationFilter{}, req.GetPageSize(), cursor)
+	listOrganizations := s.listOrganizations
+	if listOrganizations == nil {
+		listOrganizations = func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
+			return s.store.ListOrganizations(ctx, store.OrganizationFilter{}, pageSize, cursor)
+		}
+	}
+	result, err := listOrganizations(ctx, req.GetPageSize(), cursor)
 	if err != nil {
 		return nil, toStatusError(err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,6 +63,26 @@ func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	return uuid.Parse(values[0])
 }
 
+func identityIDFromContextIfPresent(ctx context.Context) (uuid.UUID, bool, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return uuid.Nil, false, nil
+	}
+	values := md.Get("x-identity-id")
+	if len(values) == 0 {
+		return uuid.Nil, false, nil
+	}
+	value := strings.TrimSpace(values[0])
+	if value == "" {
+		return uuid.Nil, false, nil
+	}
+	identityID, err := uuid.Parse(value)
+	if err != nil {
+		return uuid.Nil, true, err
+	}
+	return identityID, true, nil
+}
+
 func (s *Server) checkPermission(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) (bool, error) {
 	response, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
 		TupleKey: &authorizationv1.TupleKey{
@@ -229,17 +249,18 @@ func (s *Server) DeleteOrganization(ctx context.Context, req *organizationsv1.De
 }
 
 func (s *Server) ListOrganizations(ctx context.Context, req *organizationsv1.ListOrganizationsRequest) (*organizationsv1.ListOrganizationsResponse, error) {
-	identityID, err := identityIDFromContext(ctx)
+	identityID, hasIdentity, err := identityIDFromContextIfPresent(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
 	}
-
-	allowed, err := s.isClusterAdmin(ctx, identityID)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
-	}
-	if !allowed {
-		return nil, status.Error(codes.PermissionDenied, "missing permission to list organizations")
+	if hasIdentity {
+		allowed, err := s.isClusterAdmin(ctx, identityID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+		}
+		if !allowed {
+			return nil, status.Error(codes.PermissionDenied, "missing permission to list organizations")
+		}
 	}
 
 	cursor, err := decodePageCursor(req.GetPageToken())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,26 +63,6 @@ func identityIDFromContext(ctx context.Context) (uuid.UUID, error) {
 	return uuid.Parse(values[0])
 }
 
-func identityIDFromContextIfPresent(ctx context.Context) (uuid.UUID, bool, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return uuid.Nil, false, nil
-	}
-	values := md.Get("x-identity-id")
-	if len(values) == 0 {
-		return uuid.Nil, false, nil
-	}
-	value := strings.TrimSpace(values[0])
-	if value == "" {
-		return uuid.Nil, false, nil
-	}
-	identityID, err := uuid.Parse(value)
-	if err != nil {
-		return uuid.Nil, true, err
-	}
-	return identityID, true, nil
-}
-
 func (s *Server) checkPermission(ctx context.Context, identityID uuid.UUID, relation string, organizationID uuid.UUID) (bool, error) {
 	response, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
 		TupleKey: &authorizationv1.TupleKey{
@@ -249,18 +229,17 @@ func (s *Server) DeleteOrganization(ctx context.Context, req *organizationsv1.De
 }
 
 func (s *Server) ListOrganizations(ctx context.Context, req *organizationsv1.ListOrganizationsRequest) (*organizationsv1.ListOrganizationsResponse, error) {
-	identityID, hasIdentity, err := identityIDFromContextIfPresent(ctx)
+	identityID, err := identityIDFromContext(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
 	}
-	if hasIdentity {
-		allowed, err := s.isClusterAdmin(ctx, identityID)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
-		}
-		if !allowed {
-			return nil, status.Error(codes.PermissionDenied, "missing permission to list organizations")
-		}
+
+	allowed, err := s.isClusterAdmin(ctx, identityID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to list organizations")
 	}
 
 	cursor, err := decodePageCursor(req.GetPageToken())


### PR DESCRIPTION
## Summary
- gate ListOrganizations behind cluster-admin authorization checks
- add injectable listOrganizations hook for server tests
- add tests for cluster admin allow/deny behavior

## Testing
- GOTOOLCHAIN=local go test ./...
- GOTOOLCHAIN=local go vet ./...

Refs #22