### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -13,20 +16,18 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Deploy organizations from source
-        run: devspace dev -n platform
+        run: devspace dev
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy organizations from source with `devspace dev`, then run `agynio/e2e/.github/actions/run-tests@main`.
- Replaces the pinned bootstrap action commit with `@main`.
- Removes the namespace override from the DevSpace deploy command.
- Adds read-only workflow permissions to CI/E2E.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #27

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yaml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yaml` — passed with no errors.
- `buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/users/v1` — passed.
- `GOTOOLCHAIN=local go test ./...` — 5 passed, 0 failed, 0 skipped.
- `GOTOOLCHAIN=local go build ./...` — passed.