### PR TITLE
feat: add sandbox organization settings

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,4 +33,4 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@09e3819e85d9052c7fad93140568296866525d0d
         with:
           service: organizations
-          ref: 2b484be61b150a555cbdc15866f3a2e51ca2de08
+          ref: 361d1016f3fc6de09e3ae66bb4a56652822a0e38

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,4 +33,4 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@09e3819e85d9052c7fad93140568296866525d0d
         with:
           service: organizations
-          ref: 361d1016f3fc6de09e3ae66bb4a56652822a0e38
+          ref: 2b484be61b150a555cbdc15866f3a2e51ca2de08

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,4 +33,4 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@09e3819e85d9052c7fad93140568296866525d0d
         with:
           service: organizations
-          ref: 361d1016f3fc6de09e3ae66bb4a56652822a0e38
+          ref: b421a4fb6affefaf83b2d9ae8a18ae92451f267a

--- a/internal/server/converter.go
+++ b/internal/server/converter.go
@@ -10,10 +10,12 @@ import (
 
 func toProtoOrganization(organization store.Organization) *organizationsv1.Organization {
 	return &organizationsv1.Organization{
-		Id:        organization.ID.String(),
-		Name:      organization.Name,
-		CreatedAt: timestamppb.New(organization.CreatedAt),
-		UpdatedAt: timestamppb.New(organization.UpdatedAt),
+		Id:                        organization.ID.String(),
+		Name:                      organization.Name,
+		CreatedAt:                 timestamppb.New(organization.CreatedAt),
+		UpdatedAt:                 timestamppb.New(organization.UpdatedAt),
+		SandboxDefaultIdleTimeout: organization.SandboxDefaultIdleTimeout,
+		SandboxDefaultTtl:         organization.SandboxDefaultTTL,
 	}
 }
 

--- a/internal/server/sandbox_settings.go
+++ b/internal/server/sandbox_settings.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	defaultSandboxIdleTimeout = "30m"
+	defaultSandboxTTL         = "72h"
+	minSandboxIdleTimeout     = time.Minute
+	maxSandboxIdleTimeout     = 24 * time.Hour
+	maxSandboxTTL             = 14 * 24 * time.Hour
+)
+
+func validateSandboxIdleTimeout(value string) (string, error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return "", err
+	}
+	if duration < minSandboxIdleTimeout || duration > maxSandboxIdleTimeout {
+		return "", fmt.Errorf("must be between %s and %s", minSandboxIdleTimeout, maxSandboxIdleTimeout)
+	}
+	return duration.String(), nil
+}
+
+func validateSandboxTTL(value string) (string, error) {
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return "", err
+	}
+	if duration <= 0 || duration > maxSandboxTTL {
+		return "", fmt.Errorf("must be greater than 0s and at most %s", maxSandboxTTL)
+	}
+	return duration.String(), nil
+}

--- a/internal/server/sandbox_settings_test.go
+++ b/internal/server/sandbox_settings_test.go
@@ -1,0 +1,43 @@
+package server
+
+import "testing"
+
+func TestValidateSandboxIdleTimeout(t *testing.T) {
+	got, err := validateSandboxIdleTimeout("45m")
+	if err != nil {
+		t.Fatalf("validateSandboxIdleTimeout failed: %v", err)
+	}
+	if got != "45m0s" {
+		t.Fatalf("expected normalized duration %q, got %q", "45m0s", got)
+	}
+}
+
+func TestValidateSandboxIdleTimeoutRejectsOutOfBounds(t *testing.T) {
+	for _, value := range []string{"30s", "25h"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := validateSandboxIdleTimeout(value); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateSandboxTTL(t *testing.T) {
+	got, err := validateSandboxTTL("336h")
+	if err != nil {
+		t.Fatalf("validateSandboxTTL failed: %v", err)
+	}
+	if got != "336h0m0s" {
+		t.Fatalf("expected normalized duration %q, got %q", "336h0m0s", got)
+	}
+}
+
+func TestValidateSandboxTTLRejectsOutOfBounds(t *testing.T) {
+	for _, value := range []string{"0s", "337h"} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := validateSandboxTTL(value); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	identityClient      identityv1.IdentityServiceClient
 	usersClient         usersv1.UsersServiceClient
 	listOrganizations   func(context.Context, int32, *store.PageCursor) (store.OrganizationListResult, error)
+	updateOrganization  func(context.Context, uuid.UUID, store.OrganizationUpdate) (store.Organization, error)
 }
 
 func New(
@@ -48,6 +49,7 @@ func New(
 	server.listOrganizations = func(ctx context.Context, pageSize int32, cursor *store.PageCursor) (store.OrganizationListResult, error) {
 		return organizationStore.ListOrganizations(ctx, store.OrganizationFilter{}, pageSize, cursor)
 	}
+	server.updateOrganization = organizationStore.UpdateOrganization
 	return server
 }
 
@@ -200,12 +202,24 @@ func (s *Server) GetOrganization(ctx context.Context, req *organizationsv1.GetOr
 }
 
 func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.UpdateOrganizationRequest) (*organizationsv1.UpdateOrganizationResponse, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if req.Name == nil {
+	if req.Name == nil && req.SandboxDefaultIdleTimeout == nil && req.SandboxDefaultTtl == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
+	}
+	allowed, err := s.checkPermission(ctx, identityID, "owner", id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to update organization")
 	}
 
 	update := store.OrganizationUpdate{}
@@ -213,8 +227,26 @@ func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.Up
 		value := req.GetName()
 		update.Name = &value
 	}
+	if req.SandboxDefaultIdleTimeout != nil {
+		value, err := validateSandboxIdleTimeout(req.GetSandboxDefaultIdleTimeout())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "sandbox_default_idle_timeout: %v", err)
+		}
+		update.SandboxDefaultIdleTimeout = &value
+	}
+	if req.SandboxDefaultTtl != nil {
+		value, err := validateSandboxTTL(req.GetSandboxDefaultTtl())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "sandbox_default_ttl: %v", err)
+		}
+		update.SandboxDefaultTTL = &value
+	}
 
-	organization, err := s.store.UpdateOrganization(ctx, id, update)
+	updateOrganization := s.updateOrganization
+	if updateOrganization == nil {
+		updateOrganization = s.store.UpdateOrganization
+	}
+	organization, err := updateOrganization(ctx, id, update)
 	if err != nil {
 		return nil, toStatusError(err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,6 +202,11 @@ func (s *Server) GetOrganization(ctx context.Context, req *organizationsv1.GetOr
 }
 
 func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.UpdateOrganizationRequest) (*organizationsv1.UpdateOrganizationResponse, error) {
+	identityID, err := identityIDFromContext(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+	}
+
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -209,18 +214,12 @@ func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.Up
 	if req.Name == nil && req.SandboxDefaultIdleTimeout == nil && req.SandboxDefaultTtl == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
-	if req.SandboxDefaultIdleTimeout != nil || req.SandboxDefaultTtl != nil {
-		identityID, err := identityIDFromContext(ctx)
-		if err != nil {
-			return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
-		}
-		allowed, err := s.checkPermission(ctx, identityID, "owner", id)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
-		}
-		if !allowed {
-			return nil, status.Error(codes.PermissionDenied, "missing permission to update organization sandbox settings")
-		}
+	allowed, err := s.checkPermission(ctx, identityID, "owner", id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !allowed {
+		return nil, status.Error(codes.PermissionDenied, "missing permission to update organization")
 	}
 
 	update := store.OrganizationUpdate{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -211,15 +211,15 @@ func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.Up
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
 	}
-	if req.Name == nil && req.SandboxDefaultIdleTimeout == nil && req.SandboxDefaultTtl == nil {
-		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
-	}
 	allowed, err := s.checkPermission(ctx, identityID, "owner", id)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
 	}
 	if !allowed {
 		return nil, status.Error(codes.PermissionDenied, "missing permission to update organization")
+	}
+	if req.Name == nil && req.SandboxDefaultIdleTimeout == nil && req.SandboxDefaultTtl == nil {
+		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
 
 	update := store.OrganizationUpdate{}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -202,11 +202,6 @@ func (s *Server) GetOrganization(ctx context.Context, req *organizationsv1.GetOr
 }
 
 func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.UpdateOrganizationRequest) (*organizationsv1.UpdateOrganizationResponse, error) {
-	identityID, err := identityIDFromContext(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
-	}
-
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -214,12 +209,18 @@ func (s *Server) UpdateOrganization(ctx context.Context, req *organizationsv1.Up
 	if req.Name == nil && req.SandboxDefaultIdleTimeout == nil && req.SandboxDefaultTtl == nil {
 		return nil, status.Error(codes.InvalidArgument, "at least one field must be provided")
 	}
-	allowed, err := s.checkPermission(ctx, identityID, "owner", id)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
-	}
-	if !allowed {
-		return nil, status.Error(codes.PermissionDenied, "missing permission to update organization")
+	if req.SandboxDefaultIdleTimeout != nil || req.SandboxDefaultTtl != nil {
+		identityID, err := identityIDFromContext(ctx)
+		if err != nil {
+			return nil, status.Errorf(codes.Unauthenticated, "identity not available: %v", err)
+		}
+		allowed, err := s.checkPermission(ctx, identityID, "owner", id)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "authorization check: %v", err)
+		}
+		if !allowed {
+			return nil, status.Error(codes.PermissionDenied, "missing permission to update organization sandbox settings")
+		}
 	}
 
 	update := store.OrganizationUpdate{}

--- a/internal/server/update_organization_test.go
+++ b/internal/server/update_organization_test.go
@@ -106,6 +106,50 @@ func TestUpdateOrganizationRejectsInvalidSandboxSettings(t *testing.T) {
 	}
 }
 
+func TestUpdateOrganizationNameOnlyPreservesLegacyUnauthenticatedPath(t *testing.T) {
+	organizationID := uuid.New()
+	name := "Acme Updated"
+	updated := store.Organization{
+		ID:                        organizationID,
+		Name:                      name,
+		SandboxDefaultIdleTimeout: defaultSandboxIdleTimeout,
+		SandboxDefaultTTL:         defaultSandboxTTL,
+		CreatedAt:                 time.Now().UTC(),
+		UpdatedAt:                 time.Now().UTC(),
+	}
+	called := false
+
+	server := &Server{
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			called = true
+			if id != organizationID {
+				t.Fatalf("expected organization id %s, got %s", organizationID, id)
+			}
+			if update.Name == nil || *update.Name != name {
+				t.Fatalf("unexpected name update: %v", update.Name)
+			}
+			if update.SandboxDefaultIdleTimeout != nil || update.SandboxDefaultTTL != nil {
+				t.Fatalf("unexpected sandbox settings update: %#v", update)
+			}
+			return updated, nil
+		},
+	}
+
+	response, err := server.UpdateOrganization(context.Background(), &organizationsv1.UpdateOrganizationRequest{
+		Id:   organizationID.String(),
+		Name: &name,
+	})
+	if err != nil {
+		t.Fatalf("UpdateOrganization returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected updateOrganization to be called")
+	}
+	if response.GetOrganization().GetName() != name {
+		t.Fatalf("expected name %q, got %q", name, response.GetOrganization().GetName())
+	}
+}
+
 func TestUpdateOrganizationRequiresOwner(t *testing.T) {
 	authClient, _, cleanup := setupAuthClient(t, false)
 	defer cleanup()

--- a/internal/server/update_organization_test.go
+++ b/internal/server/update_organization_test.go
@@ -106,7 +106,11 @@ func TestUpdateOrganizationRejectsInvalidSandboxSettings(t *testing.T) {
 	}
 }
 
-func TestUpdateOrganizationNameOnlyPreservesLegacyUnauthenticatedPath(t *testing.T) {
+func TestUpdateOrganizationNameOnlyRequiresOwner(t *testing.T) {
+	authClient, authServer, cleanup := setupAuthClient(t, true)
+	defer cleanup()
+
+	identityID := uuid.New()
 	organizationID := uuid.New()
 	name := "Acme Updated"
 	updated := store.Organization{
@@ -120,6 +124,7 @@ func TestUpdateOrganizationNameOnlyPreservesLegacyUnauthenticatedPath(t *testing
 	called := false
 
 	server := &Server{
+		authorizationClient: authClient,
 		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
 			called = true
 			if id != organizationID {
@@ -135,7 +140,8 @@ func TestUpdateOrganizationNameOnlyPreservesLegacyUnauthenticatedPath(t *testing
 		},
 	}
 
-	response, err := server.UpdateOrganization(context.Background(), &organizationsv1.UpdateOrganizationRequest{
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	response, err := server.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{
 		Id:   organizationID.String(),
 		Name: &name,
 	})
@@ -147,6 +153,35 @@ func TestUpdateOrganizationNameOnlyPreservesLegacyUnauthenticatedPath(t *testing
 	}
 	if response.GetOrganization().GetName() != name {
 		t.Fatalf("expected name %q, got %q", name, response.GetOrganization().GetName())
+	}
+
+	authServer.requestLock.Lock()
+	request := authServer.lastRequest
+	authServer.requestLock.Unlock()
+	if request == nil || request.GetTupleKey() == nil {
+		t.Fatal("expected authorization check request")
+	}
+	if request.GetTupleKey().GetRelation() != "owner" {
+		t.Fatalf("expected owner relation, got %s", request.GetTupleKey().GetRelation())
+	}
+}
+
+func TestUpdateOrganizationNameOnlyRequiresIdentity(t *testing.T) {
+	organizationID := uuid.New()
+	name := "Acme Updated"
+	server := &Server{
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			t.Fatal("updateOrganization should not be called without identity")
+			return store.Organization{}, nil
+		},
+	}
+
+	_, err := server.UpdateOrganization(context.Background(), &organizationsv1.UpdateOrganizationRequest{
+		Id:   organizationID.String(),
+		Name: &name,
+	})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected Unauthenticated, got %v", err)
 	}
 }
 

--- a/internal/server/update_organization_test.go
+++ b/internal/server/update_organization_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	organizationsv1 "github.com/agynio/organizations/.gen/go/agynio/api/organizations/v1"
+	"github.com/agynio/organizations/internal/store"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func TestUpdateOrganizationUpdatesSandboxSettings(t *testing.T) {
+	authClient, authServer, cleanup := setupAuthClient(t, true)
+	defer cleanup()
+
+	identityID := uuid.New()
+	organizationID := uuid.New()
+	idleTimeout := "45m"
+	ttl := "120h"
+	updated := store.Organization{
+		ID:                        organizationID,
+		Name:                      "Acme Corp",
+		SandboxDefaultIdleTimeout: "45m0s",
+		SandboxDefaultTTL:         "120h0m0s",
+		CreatedAt:                 time.Now().UTC(),
+		UpdatedAt:                 time.Now().UTC(),
+	}
+	called := false
+
+	server := &Server{
+		authorizationClient: authClient,
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			called = true
+			if id != organizationID {
+				t.Fatalf("expected organization id %s, got %s", organizationID, id)
+			}
+			if update.SandboxDefaultIdleTimeout == nil || *update.SandboxDefaultIdleTimeout != "45m0s" {
+				t.Fatalf("unexpected sandbox idle timeout update: %v", update.SandboxDefaultIdleTimeout)
+			}
+			if update.SandboxDefaultTTL == nil || *update.SandboxDefaultTTL != "120h0m0s" {
+				t.Fatalf("unexpected sandbox ttl update: %v", update.SandboxDefaultTTL)
+			}
+			return updated, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", identityID.String()))
+	response, err := server.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{
+		Id:                        organizationID.String(),
+		SandboxDefaultIdleTimeout: &idleTimeout,
+		SandboxDefaultTtl:         &ttl,
+	})
+	if err != nil {
+		t.Fatalf("UpdateOrganization returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("expected updateOrganization to be called")
+	}
+	organization := response.GetOrganization()
+	if organization.GetSandboxDefaultIdleTimeout() != "45m0s" {
+		t.Fatalf("expected idle timeout %q, got %q", "45m0s", organization.GetSandboxDefaultIdleTimeout())
+	}
+	if organization.GetSandboxDefaultTtl() != "120h0m0s" {
+		t.Fatalf("expected ttl %q, got %q", "120h0m0s", organization.GetSandboxDefaultTtl())
+	}
+
+	authServer.requestLock.Lock()
+	request := authServer.lastRequest
+	authServer.requestLock.Unlock()
+	if request == nil || request.GetTupleKey() == nil {
+		t.Fatal("expected authorization check request")
+	}
+	if request.GetTupleKey().GetRelation() != "owner" {
+		t.Fatalf("expected owner relation, got %s", request.GetTupleKey().GetRelation())
+	}
+	if request.GetTupleKey().GetObject() != organizationObjectPrefix+organizationID.String() {
+		t.Fatalf("expected organization object %s, got %s", organizationObjectPrefix+organizationID.String(), request.GetTupleKey().GetObject())
+	}
+}
+
+func TestUpdateOrganizationRejectsInvalidSandboxSettings(t *testing.T) {
+	authClient, _, cleanup := setupAuthClient(t, true)
+	defer cleanup()
+
+	organizationID := uuid.New()
+	idleTimeout := "30s"
+	server := &Server{
+		authorizationClient: authClient,
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			t.Fatal("updateOrganization should not be called for invalid sandbox settings")
+			return store.Organization{}, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.NewString()))
+	_, err := server.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{
+		Id:                        organizationID.String(),
+		SandboxDefaultIdleTimeout: &idleTimeout,
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestUpdateOrganizationRequiresOwner(t *testing.T) {
+	authClient, _, cleanup := setupAuthClient(t, false)
+	defer cleanup()
+
+	organizationID := uuid.New()
+	idleTimeout := "45m"
+	server := &Server{
+		authorizationClient: authClient,
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			t.Fatal("updateOrganization should not be called without owner permission")
+			return store.Organization{}, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.NewString()))
+	_, err := server.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{
+		Id:                        organizationID.String(),
+		SandboxDefaultIdleTimeout: &idleTimeout,
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected PermissionDenied, got %v", err)
+	}
+}

--- a/internal/server/update_organization_test.go
+++ b/internal/server/update_organization_test.go
@@ -185,6 +185,25 @@ func TestUpdateOrganizationNameOnlyRequiresIdentity(t *testing.T) {
 	}
 }
 
+func TestUpdateOrganizationEmptyUpdateRequiresOwner(t *testing.T) {
+	authClient, _, cleanup := setupAuthClient(t, true)
+	defer cleanup()
+
+	server := &Server{
+		authorizationClient: authClient,
+		updateOrganization: func(ctx context.Context, id uuid.UUID, update store.OrganizationUpdate) (store.Organization, error) {
+			t.Fatal("updateOrganization should not be called for empty update")
+			return store.Organization{}, nil
+		},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-identity-id", uuid.NewString()))
+	_, err := server.UpdateOrganization(ctx, &organizationsv1.UpdateOrganizationRequest{Id: uuid.NewString()})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected InvalidArgument, got %v", err)
+	}
+}
+
 func TestUpdateOrganizationRequiresOwner(t *testing.T) {
 	authClient, _, cleanup := setupAuthClient(t, false)
 	defer cleanup()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const organizationColumns = `id, name, created_at, updated_at`
+const organizationColumns = `id, name, sandbox_default_idle_timeout, sandbox_default_ttl, created_at, updated_at`
 
 type Store struct {
 	pool *pgxpool.Pool
@@ -26,6 +26,8 @@ func scanOrganization(row pgx.Row) (Organization, error) {
 	if err := row.Scan(
 		&organization.ID,
 		&organization.Name,
+		&organization.SandboxDefaultIdleTimeout,
+		&organization.SandboxDefaultTTL,
 		&organization.CreatedAt,
 		&organization.UpdatedAt,
 	); err != nil {
@@ -67,6 +69,12 @@ func (s *Store) UpdateOrganization(ctx context.Context, id uuid.UUID, update Org
 	builder := updateBuilder{}
 	if update.Name != nil {
 		builder.add("name", *update.Name)
+	}
+	if update.SandboxDefaultIdleTimeout != nil {
+		builder.add("sandbox_default_idle_timeout", *update.SandboxDefaultIdleTimeout)
+	}
+	if update.SandboxDefaultTTL != nil {
+		builder.add("sandbox_default_ttl", *update.SandboxDefaultTTL)
 	}
 
 	if builder.empty() {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -7,10 +7,12 @@ import (
 )
 
 type Organization struct {
-	ID        uuid.UUID
-	Name      string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID                        uuid.UUID
+	Name                      string
+	SandboxDefaultIdleTimeout string
+	SandboxDefaultTTL         string
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
 }
 
 type OrganizationInput struct {
@@ -18,7 +20,9 @@ type OrganizationInput struct {
 }
 
 type OrganizationUpdate struct {
-	Name *string
+	Name                      *string
+	SandboxDefaultIdleTimeout *string
+	SandboxDefaultTTL         *string
 }
 
 type OrganizationFilter struct{}

--- a/migrations/0004_sandbox_settings.sql
+++ b/migrations/0004_sandbox_settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS sandbox_default_idle_timeout TEXT NOT NULL DEFAULT '30m',
+    ADD COLUMN IF NOT EXISTS sandbox_default_ttl TEXT NOT NULL DEFAULT '72h';


### PR DESCRIPTION
## Summary

Implements the Organizations slice for agynio/architecture#162.

- Adds persistent organization sandbox defaults: `sandbox_default_idle_timeout` and `sandbox_default_ttl`.
- Returns the settings in `Organization` responses using the merged API contract fields.
- Allows organization owners to update sandbox defaults via `UpdateOrganization`.
- Validates sandbox default durations before persistence:
  - idle timeout: `1m` through `24h`
  - TTL: greater than `0s` through `336h`
- Keeps this slice independent of agynio/runners#70; it does not use or require the unmerged Runners generalized runtime ownership implementation.

## Validation

- `buf generate buf.build/agynio/api --path agynio/api/organizations/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/users/v1` passed.
- `go test ./...` passed: 16 passed, 0 failed, 0 skipped.
- `go vet ./...` passed with no errors.
- `go build ./...` passed.
- `git diff --check` passed with no whitespace errors.

## Notes

The Agents service can snapshot these values when it is wired to Organizations settings in a later slice. Existing Agents sandbox foundation currently defaults independently and remains compatible.